### PR TITLE
Fixed minor issues in English translation

### DIFF
--- a/po/com.github.bartzaalberg.alias.pot
+++ b/po/com.github.bartzaalberg.alias.pot
@@ -34,7 +34,7 @@ msgid "Search for names of aliases"
 msgstr ""
 
 #: ../src/Components/HeaderBar.vala:45 ../src/Views/CreateView.vala:9
-msgid "Add a new alias"
+msgid "Add new alias"
 msgstr ""
 
 #: ../src/Components/HeaderBar.vala:52
@@ -58,7 +58,7 @@ msgid "Name:"
 msgstr ""
 
 #: ../src/Components/FormComponent.vala:14
-msgid "command:*"
+msgid "Command:"
 msgstr ""
 
 #: ../src/ListBox.vala:59
@@ -99,7 +99,7 @@ msgstr ""
 
 #: ../src/Views/WelcomeView.vala:9
 msgid ""
-"Some lines of code has to be added to your .bashrc file to use your aliases."
+"Few lines of code will be added to your .bashrc file, to use your aliases."
 msgstr ""
 
 #: ../src/Views/WelcomeView.vala:10


### PR DESCRIPTION
When creating new alias, name and command titles should be in uppercase, but only one of them was. Command title does not need to have the asterisk, because the user can't add the alias without both fields filled, so I removed that. And I changed "Some lines of code has to be added..." to "Few lines of code will be added" so the user would know they have not been added yet.

BTW - great app, really aprreciate something like this!