### PR TITLE
Use Gtk.Application instead of deprecated Granite.Application

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,13 +1,10 @@
-using Granite.Widgets;
-
 namespace Application {
-public class App:Granite.Application {
+public class App:Gtk.Application {
 
     public static MainWindow window = null;
     public static GLib.Settings settings;
 
     construct {
-        program_name = Constants.APPLICATION_NAME;
         application_id = Constants.APPLICATION_NAME;
         settings = new GLib.Settings (Constants.APPLICATION_NAME);
     }


### PR DESCRIPTION
[Granite.Application is deprecated](https://github.com/elementary/granite/blob/3c25b6c95e5ddf3fcc3bdf8bf1014f6d2246e677/lib/Application.vala#L25) since 0.5.0 and should not be used anymore.
